### PR TITLE
Add weeklyAverage and weightLog utilities

### DIFF
--- a/.codex/tasks.json
+++ b/.codex/tasks.json
@@ -1,0 +1,16 @@
+{
+  "tasks": [
+    {
+      "name": "weeklyAverage util",
+      "file": "js/weeklyAverage.js",
+      "prompt": "Create js/weeklyAverage.js with a pure ES module:\nexport function weeklyAverage(weights){ if(!weights.length) return 0; const s=weights.reduce((a,b)=>a+b,0); return Math.round((s/weights.length)*10)/10; }",
+      "tests": "node -e \"import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});\""
+    },
+    {
+      "name": "weightLog helper",
+      "file": "js/weightLog.js",
+      "prompt": "Create js/weightLog.js with addWeight(dateISO,lbs) + getWeekAverage(weekStartISO) using localStorage key 'weights'. addWeight pushes {d,l}. getWeekAverage averages entries Mon-Sun (same YYYY-WW).",
+      "tests": "node -e \"globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});\""
+    }
+  ]
+}

--- a/js/weeklyAverage.js
+++ b/js/weeklyAverage.js
@@ -1,0 +1,5 @@
+export function weeklyAverage(weights) {
+  if (!weights.length) return 0;
+  const s = weights.reduce((a, b) => a + b, 0);
+  return Math.round((s / weights.length) * 10) / 10;
+}

--- a/js/weightLog.js
+++ b/js/weightLog.js
@@ -1,0 +1,33 @@
+const STORAGE_KEY = 'weights';
+
+function readWeights() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+function writeWeights(arr) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(arr));
+}
+
+export function addWeight(dateISO, lbs) {
+  const arr = readWeights();
+  arr.push({ d: dateISO, l: lbs });
+  writeWeights(arr);
+}
+
+function weekStart(dateISO) {
+  const d = new Date(dateISO);
+  const day = d.getUTCDay();
+  const diff = (day + 6) % 7; // days since Monday
+  d.setUTCDate(d.getUTCDate() - diff);
+  return d.toISOString().slice(0, 10);
+}
+
+export function getWeekAverage(weekStartISO) {
+  const arr = readWeights();
+  const start = weekStart(weekStartISO);
+  const weekEntries = arr.filter(e => weekStart(e.d) === start);
+  if (!weekEntries.length) return 0;
+  const sum = weekEntries.reduce((s, e) => s + e.l, 0);
+  return sum / weekEntries.length;
+}


### PR DESCRIPTION
## Summary
- define automation tasks for weight utilities
- add weeklyAverage module
- add weightLog helper functions

## Testing
- `node -e "import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});"`
- `node -e "globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});"`