### PR TITLE
Add weekly average utility and fix calorie correction

### DIFF
--- a/js/calorieCorrection.js
+++ b/js/calorieCorrection.js
@@ -1,0 +1,11 @@
+/**
+ * calorieCorrection
+ * @param {number} targetWeeklyLbs – desired lbs change per week (neg = lose, pos = gain)
+ * @param {number} actualWeeklyLbs – actual lbs change last week
+ * @returns {number} daily kcal adjustment (neg = cut, pos = add) rounded to nearest 25
+ * Uses formula: (targetWeeklyLbs - actualWeeklyLbs) * 3500 / 7
+ */
+export function calorieCorrection(targetWeeklyLbs, actualWeeklyLbs) {
+  const adjustment = (targetWeeklyLbs - actualWeeklyLbs) * 3500 / 7;
+  return Math.round(adjustment / 25) * 25;
+}

--- a/js/weeklyAverage.js
+++ b/js/weeklyAverage.js
@@ -1,0 +1,10 @@
+/**
+ * weeklyAverage
+ * @param {number[]} weights – array of numeric body-weights
+ * @returns {number} arithmetic mean rounded to one decimal
+ */
+export function weeklyAverage(weights) {
+  if (!weights.length) return 0;
+  const sum = weights.reduce((a, b) => a + b, 0);
+  return Math.round((sum / weights.length) * 10) / 10;
+}


### PR DESCRIPTION
## Summary
- fix calorie correction formula so deficit returns negative number
- add weeklyAverage utility for computing mean weight

## Testing
- `node -e "import('./js/calorieCorrection.js').then(m=>{if(m.calorieCorrection(-1.5,-1)!==-250)process.exit(1);});"`
- `node -e "import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});"`