### PR TITLE
Add mainCalc UI handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,5 +481,6 @@
     <script type="module" src="./src/app.js"></script>
     <!-- browser form handler -->
     <script type="module" src="./src/ui/calcForm.js"></script>
+    <script type="module" src="./src/ui/mainCalc.js"></script>
   </body>
 </html>

--- a/src/ui/mainCalc.js
+++ b/src/ui/mainCalc.js
@@ -1,0 +1,39 @@
+import { getMacros } from '../core/rd2_core.js';
+
+function init() {
+  const calcBtn = document.querySelector(
+    '#macroCalculator button[type="submit"], #macroCalculator button'
+  );
+  const output = document.getElementById('basicResults');
+
+  if (!calcBtn || !output) return;
+
+  calcBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+
+    const params = {
+      weight:    +document.getElementById('weight').value,
+      gender:     document.getElementById('gender').value,
+      intensity:  document.getElementById('activity').value,
+      goal:       document.getElementById('goal').value,
+      meals:     +document.getElementById('meals').value || 4
+    };
+
+    try {
+      const res = getMacros(params);
+      console.table(res);  // proof-of-life
+      output.textContent = '✓ Core engine received input (see console).';
+      output.style.color = '';
+    } catch (e) {
+      output.textContent = e.message;
+      output.style.color = 'red';
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+


### PR DESCRIPTION
## Summary
- add `mainCalc.js` to glue basic form to the core macro engine
- load the new handler in `index.html`

## Testing
- `node -e "import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});"`
- `node -e "globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});"`
