### PR TITLE
Add mainCalc UI handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,39 +243,6 @@
     </style>
 </head>
 <body>
-    <section id="macroCalcSection">
-      <h2>Quick Macro Calculator</h2>
-
-      <form id="macroForm">
-        <label>Weight (lb): <input name="weight" type="number" required></label>
-        <label>Gender:
-          <select name="gender">
-            <option value="male">Male</option>
-            <option value="female">Female</option>
-          </select>
-        </label>
-        <label>Intensity:
-          <select name="intensity">
-            <option value="Non Training">Non Training</option>
-            <option value="Light">Light</option>
-            <option value="Moderate">Moderate</option>
-            <option value="Hard">Hard</option>
-          </select>
-        </label>
-        <label>Goal:
-          <select name="goal">
-            <option value="maintain">Maintain</option>
-            <option value="cut">Cut</option>
-            <option value="bulk">Bulk</option>
-          </select>
-        </label>
-        <label>Meals / day: <input name="meals" type="number" value="4" min="1"></label>
-
-        <button type="submit">Calculate</button>
-      </form>
-
-      <div id="macroResults" style="margin-top:1rem;"></div>
-    </section>
 
     <div class="container">
         <header>
@@ -481,5 +448,6 @@
     <script type="module" src="./src/app.js"></script>
     <!-- browser form handler -->
     <script type="module" src="./src/ui/calcForm.js"></script>
+    <script type="module" src="./src/ui/mainCalc.js"></script>
   </body>
 </html>

--- a/src/ui/mainCalc.js
+++ b/src/ui/mainCalc.js
@@ -1,0 +1,31 @@
+import { getMacros } from '../core/rd2_core.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Big form elements (already present in the v2 UI)
+  const calcBtn  = document.querySelector('#macroCalculator button[type="submit"], #macroCalculator button');
+  const output   = document.getElementById('basicResults');   // blank region in v2 UI
+
+  if (!calcBtn) return;   // safety
+
+  calcBtn.addEventListener('click', ev => {
+    ev.preventDefault();
+
+    const params = {
+      weight:   +document.getElementById('weight').value,
+      gender:    document.getElementById('gender').value,
+      intensity: document.getElementById('activity').value,   // v2 uses “activity” for day type
+      goal:      document.getElementById('goal').value,
+      meals:    +document.getElementById('meals').value || 4
+    };
+
+    try {
+      const res = getMacros(params);
+      console.table(res);               // proof-of-life
+      output.textContent = '✓ Core engine received input (see console for details).';
+    } catch (e) {
+      output.textContent = e.message;
+      output.style.color = 'red';
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `mainCalc.js` to glue basic form to the core macro engine
- load the new handler in `index.html`
- remove the obsolete quick form section

## Testing
- `node -e "import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});"`
- `node -e "globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});"`
