### PR TITLE
Fix tasks.json structure

### DIFF
--- a/.codex/tasks.json
+++ b/.codex/tasks.json
@@ -11,21 +11,18 @@
       "file": "js/weightLog.js",
       "prompt": "Create js/weightLog.js with addWeight(dateISO,lbs) + getWeekAverage(weekStartISO) using localStorage key 'weights'. addWeight pushes {d,l}. getWeekAverage averages entries Mon-Sun (same YYYY-WW).",
       "tests": "node -e \"globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});\""
-    }
-  ]
-}
-
-,
+    },
     {
       "name": "noop",
       "file": "noop.txt",
       "prompt": "Create noop.txt that just contains the word ok",
       "tests": "echo ok"
+    },
+    {
+      "name": "validateMacros util",
+      "file": "js/validateMacros.js",
+      "prompt": "Create js/validateMacros.js with one function:\nexport function validateMacros(macros,bw){\n  /* macros={p,c,f}; bw=body-weight in lbs */\n  const errors=[];\n  if(macros.p < bw*0.8) errors.push('Protein below 0.8 g/lb');\n  if(macros.f < bw*0.3) errors.push('Fat below 0.3 g/lb');\n  return errors;\n}",
+      "tests": "node -e \"import('./js/validateMacros.js').then(m=>{const e=m.validateMacros({p:100,c:300,f:30},200);if(e.length!==2)process.exit(1);});\""
     }
-,
-{
-  "name": "validateMacros util",
-  "file": "js/validateMacros.js",
-  "prompt": "Create js/validateMacros.js with one function:\nexport function validateMacros(macros,bw){\n  /* macros={p,c,f}; bw=body-weight in lbs */\n  const errors=[];\n  if(macros.p < bw*0.8) errors.push('Protein below 0.8 g/lb');\n  if(macros.f < bw*0.3) errors.push('Fat below 0.3 g/lb');\n  return errors;\n}",
-  "tests": "node -e \"import('./js/validateMacros.js').then(m=>{const e=m.validateMacros({p:100,c:300,f:30},200);if(e.length!==2)process.exit(1);});\""
+  ]
 }

--- a/src/ui/mainCalc.js
+++ b/src/ui/mainCalc.js
@@ -1,6 +1,6 @@
 /* src/ui/mainCalc.js — auto-calculates macros whenever inputs change */
 import { getMacros } from '../core/rd2_core.js';
-import { validateMacros } from '../js/validateMacros.js';
+import { validateMacros } from '../../js/validateMacros.js';
 
 function init() {
   const output    = document.getElementById('basicResults');

--- a/src/ui/progressCalc.js
+++ b/src/ui/progressCalc.js
@@ -1,4 +1,4 @@
-import { weeklyAverage } from '../js/weeklyAverage.js';
+import { weeklyAverage } from '../../js/weeklyAverage.js';
 import { getLastWeekWeights } from './weightLogUI.js';
 
 function init() {

--- a/src/ui/weightLogUI.js
+++ b/src/ui/weightLogUI.js
@@ -1,4 +1,4 @@
-import { addWeight, getLast7 } from '../js/weightLog.js';
+import { addWeight, getLast7 } from '../../js/weightLog.js';
 
 document.getElementById('logWeightBtn').addEventListener('click', () => {
   const w = +document.getElementById('todayWeight').value;


### PR DESCRIPTION
## Summary
- rewrite `.codex/tasks.json` so that a single object with an array `tasks` contains all tasks in order
- correct UI import paths for module resolution

## Testing
- `jq . .codex/tasks.json`
- `node -e "import('./js/weeklyAverage.js').then(m=>{const w=[200,199,201,200,200,199,200];if(m.weeklyAverage(w)!==199.9)process.exit(1);});"`
- `node -e "globalThis.localStorage={_:{},setItem(k,v){this._[k]=v},getItem(k){return this._[k]}};import('./js/weightLog.js').then(m=>{m.addWeight('2025-05-26',200);m.addWeight('2025-05-27',199);if(Math.round(m.getWeekAverage('2025-05-26'))!==200)process.exit(1);});"`
- `node -e "import('./js/validateMacros.js').then(m=>{const e=m.validateMacros({p:100,c:300,f:30},200);if(e.length!==2)process.exit(1);});"`
- `echo ok`


------
https://chatgpt.com/codex/tasks/task_e_683a168dc5308323b8858f2fc59d9abd