### PR TITLE
Initialize TypeScript/React scaffold

### DIFF
--- a/core/formulas.ts
+++ b/core/formulas.ts
@@ -1,0 +1,1 @@
+export const formulas = {};

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,0 +1,3 @@
+export * from './lookupTables';
+export * from './formulas';
+export * from './validate';

--- a/core/lookupTables.ts
+++ b/core/lookupTables.ts
@@ -1,0 +1,1 @@
+export const lookup = {};

--- a/core/validate.ts
+++ b/core/validate.ts
@@ -1,0 +1,1 @@
+export const validate = () => [];

--- a/frontend/components/InputForm.tsx
+++ b/frontend/components/InputForm.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const InputForm = () => {
+  return <form>{/* TODO: form fields */}</form>;
+};
+
+export default InputForm;

--- a/frontend/components/MealTable.tsx
+++ b/frontend/components/MealTable.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MealTable = () => {
+  return <table>{/* TODO: table */}</table>;
+};
+
+export default MealTable;

--- a/frontend/components/ResultCard.tsx
+++ b/frontend/components/ResultCard.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ResultCard = () => {
+  return <div>{/* TODO: results */}</div>;
+};
+
+export default ResultCard;

--- a/frontend/hooks/useMacroCalc.ts
+++ b/frontend/hooks/useMacroCalc.ts
@@ -1,0 +1,5 @@
+const useMacroCalc = () => {
+  return {};
+};
+
+export default useMacroCalc;

--- a/frontend/main.tsx
+++ b/frontend/main.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Calculator from './pages/Calculator';
+
+ReactDOM.render(<Calculator />, document.getElementById('root'));

--- a/frontend/pages/Calculator.tsx
+++ b/frontend/pages/Calculator.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import InputForm from '../components/InputForm';
+import ResultCard from '../components/ResultCard';
+import MealTable from '../components/MealTable';
+
+const Calculator = () => (
+  <div>
+    <InputForm />
+    <ResultCard />
+    <MealTable />
+  </div>
+);
+
+export default Calculator;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "macro-calculator",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "vite": "latest",
+    "vitest": "latest",
+    "typescript": "latest"
+  }
+}

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('core placeholder', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add core module stubs and an index
- add React placeholders for calculator UI
- add Vitest spec placeholder
- create package.json with vite and vitest setup

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a334d3abc8323aeb418d91f463071